### PR TITLE
Allow user to configure his own fields to display in alerts list

### DIFF
--- a/tygenie/app.py
+++ b/tygenie/app.py
@@ -2,12 +2,15 @@ import argparse
 import os
 
 from desktop_notifier import DesktopNotifier
+from textual import on
 from textual.app import App
 from textual.binding import Binding
+from textual.widgets import Footer
 
 import tygenie.config as config
 import tygenie.logger as logger
 import tygenie.opsgenie as opsgenie
+from tygenie.screen import TyScreen
 import tygenie.screens.add_note
 import tygenie.screens.alerts
 import tygenie.screens.settings
@@ -56,8 +59,11 @@ class TygenieApp(App):
             formatter=plugins.get("alert_description_formatter", None)
         )
 
-    def reload(self):
+    @on(tygenie.screens.settings.SettingsScreen.SettingsUpdated)
+    async def reload(self):
         self.load_plugins()
+        self.refresh_bindings()
+        await self.get_screen(consts.ALERTS_SCREEN_NAME).reload()
 
     def get_theme_variable_defaults(self) -> dict[str, str]:
         theme_config = self.get_theme(self.theme)

--- a/tygenie/config.py
+++ b/tygenie/config.py
@@ -112,6 +112,11 @@ class Config:
             .get("palette", "ctrl+p")
         )
 
+        # Add displayed_field as a key/value structure
+        self.config.get("tygenie", {})["displayed_fields"] = self.config.get(
+            "tygenie", {}
+        ).get("displayed_fields", {})
+
         self.save(self.config)
 
 

--- a/tygenie/screens/alerts.py
+++ b/tygenie/screens/alerts.py
@@ -29,7 +29,6 @@ import tygenie.config as config
 import tygenie.opsgenie as opsgenie
 from tygenie import consts
 from tygenie.screen import TyScreen
-from tygenie.screens.settings import SettingsScreen
 from tygenie.widgets.alert_actions import AlertActionContainer
 from tygenie.widgets.alert_details import (
     AlertDetails,
@@ -266,10 +265,8 @@ class AlertsScreen(TyScreen):
         super().__init__()
         self.app: "TygenieApp"
 
-    @on(SettingsScreen.SettingsUpdated)
-    async def recompose_app(self):
+    async def reload(self):
         await self.recompose()
-        self.lookup_data()
 
     def on_screen_resume(self):
         self.lookup_data()
@@ -515,8 +512,15 @@ class AlertsScreen(TyScreen):
             for index, alert in enumerate(alerts):
                 key = f"data_table_{alert.id}"
                 self.app.alerts_list_formatter.alert = alert
+                formatted_values = self.app.alerts_list_formatter.format()
                 table.add_row(
-                    *tuple(self.app.alerts_list_formatter.format().values()), key=key
+                    *tuple(
+                        [
+                            formatted_values[f]
+                            for f in self.app.alerts_list_formatter.displayed_fields.keys()
+                        ]
+                    ),
+                    key=key,
                 )
                 # If this is the alert selected before the update, keep coordinates
                 # to be the one selected

--- a/tygenie/screens/settings.py
+++ b/tygenie/screens/settings.py
@@ -56,15 +56,15 @@ class SettingsScreen(TyScreen):
         )
         yield Footer()
 
-    def action_save_config(self):
-        self.save_config()
+    async def action_save_config(self):
+        await self.save_config()
 
     def action_activate_alerts_screen(self):
         if self.has_changed:
             self.post_message(self.SettingsUpdated())
         self.app.switch_screen(f"{consts.ALERTS_SCREEN_NAME}")
 
-    def _save_config(self):
+    async def _save_config(self):
         textarea = self.query_one("#settings_textarea", TextArea)
         try:
             original_json = json.loads(self.original_text)
@@ -90,17 +90,17 @@ class SettingsScreen(TyScreen):
                 opsgenie.reload()
                 logger.reload()
 
-                self.app.reload()
+                await self.app.reload()
             except Exception as e:
                 self.notify(severity="error", message=f"Failed to relaod app: {e}")
 
-    def save_config(self):
-        self._save_config()
+    async def save_config(self):
+        await self._save_config()
         if config.ty_config.sample_copied:
             self.notify(f"Sample copied: {config.ty_config.sample_copied}")
             # As it is the first config, go back to alerts list
             self.action_activate_alerts_screen()
 
-    def on_button_pressed(self, event: Button.Pressed) -> None:
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "save":
-            self.save_config()
+            await self.save_config()


### PR DESCRIPTION
To display some fields a new configuration parameters has been added under tygenie entry:

```json
"tygenie": {
    "displayed_fields": {
        "message": "Message",
       "duration": "Open Since"
    }
```

The only fields displayed will be message and duration with table headers respectively set to Message and Open Since
If no fields are set it will take the display_fields class method of the formater.
