### PR TITLE
Fix #23 by moving to textual 2.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "pendulum==3.0.0",
   "python_dateutil==2.9.0.post0",
   "rich==13.9.4",
-  "textual[syntax]==1.0.0",
+  "textual[syntax]==2.0.4",
   "udatetime==0.0.17",
 ]
 requires-python = ">=3.11"

--- a/tygenie/screens/alerts.py
+++ b/tygenie/screens/alerts.py
@@ -10,6 +10,7 @@ from textual import on, work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Vertical
+from textual.content import Content
 from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import reactive
@@ -273,17 +274,17 @@ class AlertsScreen(TyScreen):
 
     def _update_paging_label(self):
         label = (
-            f"[orange1]Page:[/orange1] [b]{self.page}/{ceil(self.total_alerts / self.opsgenie_query.limit)}[/b]"
-            f" | [orange1]Displayed:[/orange1] [b]{self.first_alert_count}-{self.last_alert_count}/{self.total_alerts}[/b]"
-            f' | [orange1]Filter:[/orange1] [b]{config.ty_config.tygenie.get("filters", "")[self.opsgenie_query.current_filter]["description"]}[/b]'
+            f"[$accent]Page:[/] [b]{self.page}/{ceil(self.total_alerts / self.opsgenie_query.limit)}[/b]"
+            f" | [$accent]Displayed:[/] [b]{self.first_alert_count}-{self.last_alert_count}/{self.total_alerts}[/b]"
+            f' | [$accent]Filter:[/] [b]{config.ty_config.tygenie.get("filters", "")[self.opsgenie_query.current_filter]["description"]}[/b]'
         )
 
         if config.ty_config.opsgenie.get("on_call_schedule_ids"):
-            label += (
-                f" | [orange1]OnCall:[/orange1] [b]{self.current_on_call_member}[/b]"
-            )
+            label += f" | [$accent]OnCall:[/] [b]{self.current_on_call_member}[/b]"
 
-        self.query_one("#alerts_list_switcher", ContentSwitcher).border_subtitle = label
+        self.query_one("#alerts_list_switcher", ContentSwitcher).border_subtitle = (
+            Content.from_markup(label)
+        )
 
     def update_paging_label(self):
         try:
@@ -815,10 +816,12 @@ class AlertsScreen(TyScreen):
         except CellDoesNotExist:
             return None
 
-    @on(AlertDetails.UpdateAlertDetailsTitle)
+    @on(AlertDetails.UpdateAlertDetails)
     def _update_alert_details(self, event):
         alert_detail_title = self.query_one("#alert_details_title", AlertDetailTitle)
-        alert_detail_title.title = event.alert.message
+        alert_detail_title.title = Content.from_markup(
+            "$message", message=event.alert.message
+        )
 
         def set_class_handler(css_class):
             classes = ["open", "closed", "acked"]

--- a/tygenie/widgets/alert_actions.py
+++ b/tygenie/widgets/alert_actions.py
@@ -29,7 +29,7 @@ class AlertActionContainer(Widget):
 
     def compose(self) -> ComposeResult:
         self.border_title = "Actions"
-        self.border_subtitle = f"[orange1]Version:[/orange1] [b]{VERSION}[/b]"
+        self.border_subtitle = f"[$accent]Version:[/] [b]{VERSION}[/b]"
         with Horizontal(id="alert_action_horizontal_container"):
             yield TagValueInput(id="tag_value_container")
             yield Button(

--- a/tygenie/widgets/alert_details.py
+++ b/tygenie/widgets/alert_details.py
@@ -1,5 +1,6 @@
 from rich.text import Text
 from textual.containers import VerticalScroll
+from textual.content import Content
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
@@ -26,10 +27,10 @@ class AlertDetailsTabbedContent(TygenieTabbedContent):
 
 class AlertDetailTitle(Static):
 
-    title = reactive(Text())
+    title = reactive(Content(""))
 
     def watch_title(self):
-        self.update(self.title)
+        self.update(Content.from_markup("$title", title=self.title))
 
 
 class AlertDetails(Widget):
@@ -95,7 +96,7 @@ class AlertDetails(Widget):
                 with VerticalScroll():
                     yield Pretty(None, id="pretty_raw_alert_detail")
 
-    class UpdateAlertDetailsTitle(Message):
+    class UpdateAlertDetails(Message):
 
         def __init__(self, alert) -> None:
             self.alert = alert.data
@@ -113,6 +114,6 @@ class AlertDetails(Widget):
 
         if alert is not None:
             # Update alert_detail_title
-            self.post_message(self.UpdateAlertDetailsTitle(alert=alert))
+            self.post_message(self.UpdateAlertDetails(alert=alert))
         else:
             self.notify(severity="error", message="Unable to get alert detail")


### PR DESCRIPTION
- Upgrade to textual 2.0.4 and fix code impacted by breaking changes
- Renamed UpdateAlertDetailsTitle to UpdateAlertDetails as the action behind is not title centric.