### PR TITLE
Added #24: filter can now use saved search registered on opsgenie

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "python_dateutil==2.9.0.post0",
   "rich==13.9.4",
   "semver==3.0.1",
-  "textual[syntax]==2.0.4",
+  "textual[syntax]==2.1.2",
   "udatetime==0.0.17",
 ]
 requires-python = ">=3.11"

--- a/tygenie/config.py
+++ b/tygenie/config.py
@@ -117,6 +117,12 @@ class Config:
             "tygenie", {}
         ).get("displayed_fields", {})
 
+        # Add enable_saved_searches feature flip
+        # Set default value to True
+        self.config.get("tygenie", {})["enable_saved_searches"] = self.config.get(
+            "tygenie", {}
+        ).get("enable_saved_searches", True)
+
         self.save(self.config)
 
 

--- a/tygenie/tygenie.tcss
+++ b/tygenie/tygenie.tcss
@@ -134,22 +134,30 @@
   width: auto;
 }
 
+#alert_action_horizontal_container > Button:hover {
+  background: $primary;
+}
+
+
 #open_in_webbrowser {
   height: auto;
   width: auto;
   margin-left: 1;
+  border: blank;
 }
 
 #add_note {
   height: auto;
   width: auto;
-  margin: 0 0 0 1;
+  margin-left: 1;
+  border: blank;
 }
 
 #tag_alert {
   height: auto;
   width: auto;
   margin-left: 1;
+  border: blank;
 }
 
 #tag_value_container {
@@ -165,9 +173,9 @@
 #tag_label {
   height: auto;
   content-align: right middle;
-  padding-top: 1;
   width: auto;
   color: $text-muted;
+  border: blank;
 }
 
 #tag_input {
@@ -183,6 +191,10 @@
   height: 1fr;
 }
 
+#saved_searches {
+  height: auto;
+  width: 60;
+}
 
 /* Add note screen */
 AddNoteScreen {

--- a/tygenie/widgets/alert_actions.py
+++ b/tygenie/widgets/alert_actions.py
@@ -4,13 +4,15 @@ import semver
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal
+from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
-from textual.widgets import Button
+from textual.widgets import Button, Select
 import tygenie.logger as ty_logger
 
 from tygenie import consts
+import tygenie.opsgenie as opsgenie
 from tygenie.config import ty_config
 from tygenie.widgets.input import TagValueInput
 
@@ -19,6 +21,7 @@ class AlertActionContainer(Widget):
 
     tag_value: reactive = reactive("", recompose=True)
     version: reactive = reactive(f"v{consts.VERSION}", recompose=True)
+    saved_searches: reactive = reactive([], recompose=True)
 
     async def watch_tag_value(self):
         input = self.query_one("#tag_alert", Button)
@@ -28,6 +31,14 @@ class AlertActionContainer(Widget):
     async def watch_version(self):
         self.border_subtitle = self.version
         await self.recompose()
+
+    async def watch_saved_searches(self):
+        try:
+            select = self.query_one("#saved_searches", Select)
+            select.set_options(self.saved_searches)
+            await self.recompose()
+        except NoMatches:
+            pass
 
     def __init__(self, tag_value: str = "", **kwargs) -> None:
         super().__init__(**kwargs)
@@ -49,6 +60,13 @@ class AlertActionContainer(Widget):
                 id="open_in_webbrowser",
             )
             yield Button(label="Add note", name="add_note", id="add_note")
+            if ty_config.tygenie.get("enable_saved_searches", True):
+                yield Select(
+                    id="saved_searches",
+                    options=self.saved_searches,
+                    allow_blank=True,
+                    prompt="Use saved search",
+                )
 
     class OpenInBrowser(Message):
         """A message to indicate that we have to open selected alert in webbrowser"""
@@ -64,12 +82,27 @@ class AlertActionContainer(Widget):
 
     async def on_mount(self):
         self.send_check_tygenie_version_message()
+        self.send_list_saved_searches()
         # Check every 6 hours for new version
         self.set_interval(6 * 60 * 60, self.send_check_tygenie_version_message)
 
-    @work(exclusive=True, exit_on_error=True, thread=True)
+    class ListSavedSearches(Message):
+        """A message"""
+
+    class LookupDataWithSearchIdentifier(Message):
+        """A message"""
+
+        def __init__(self, search_identifier: str):
+            super().__init__()
+            self.search_identifier = search_identifier
+
+    @work(exclusive=False, exit_on_error=True, thread=True)
     def send_check_tygenie_version_message(self):
         self.post_message(self.CheckTygenieNewVersion())
+
+    @work(exclusive=False, exit_on_error=True, thread=True)
+    def send_list_saved_searches(self):
+        self.post_message(self.ListSavedSearches())
 
     def on_button_pressed(self, event: Button.Pressed):
         if event.button.name == "open_in_webbrowser":
@@ -84,7 +117,6 @@ class AlertActionContainer(Widget):
         self.tag_value = message.label
 
     @on(CheckTygenieNewVersion)
-    @work(exclusive=True, exit_on_error=True, thread=False)
     async def check_tygenie_new_version(self):
         ty_logger.logger.log("Checking latest Tygenie release...")
         try:
@@ -96,8 +128,33 @@ class AlertActionContainer(Widget):
 
             if semver.compare(consts.VERSION, latest_version) < 0:
                 ty_logger.logger.log(f"New version found: {latest_version}")
-                self.version = (
-                    f"v{consts.VERSION} - [$text-error]v{latest_version} available![/]"
-                )
+                self.version = f"v{consts.VERSION} - [$text-success][r]v{latest_version} available![/][/]"
         except Exception:
+            pass
+
+    @on(ListSavedSearches)
+    async def list_saved_searches(self):
+        ty_logger.logger.log("List saved searches ...")
+        try:
+            saved_searches = await opsgenie.client.list_saved_searches()
+
+            self.saved_searches = [
+                (s.name, s.id)
+                for s in sorted(saved_searches.data, key=lambda x: x.name.lower())
+            ]
+        except Exception as e:
+            ty_logger.logger.log(f"[EXCEPTION] {e}")
+            pass
+
+    def on_select_changed(self, message: Message):
+        try:
+            # let's find the select option
+            search_identifier = [
+                i for i in self.saved_searches if i[1] == message.value
+            ][0]
+            self.post_message(
+                self.LookupDataWithSearchIdentifier(search_identifier=search_identifier)
+            )
+        except Exception as e:
+            ty_logger.logger.log(f"[EXCEPTION] {e}")
             pass

--- a/tygenie/widgets/alert_details.py
+++ b/tygenie/widgets/alert_details.py
@@ -1,4 +1,3 @@
-from rich.text import Text
 from textual.containers import VerticalScroll
 from textual.content import Content
 from textual.message import Message
@@ -36,7 +35,7 @@ class AlertDetailTitle(Static):
 class AlertDetails(Widget):
 
     DEFAULT_CSS = """\
-    RawAlertDetails {
+    AlertDetails {
         & #no_alert_details_label {
             height: 1fr;
             hatch: right $surface-lighten-1 70%;
@@ -48,6 +47,11 @@ class AlertDetails(Widget):
         }
 
         & #no_alert_tags_label {
+            height: 1fr;
+            hatch: right $surface-lighten-1 70%;
+        }
+
+        & #no_alert_raw_label {
             height: 1fr;
             hatch: right $surface-lighten-1 70%;
         }
@@ -70,7 +74,7 @@ class AlertDetails(Widget):
             with TabPane("Details", id="tabpane-details"):
                 with ContentSwitcher(initial=None, id="alert_details_details_switcher"):
                     yield CenterMiddle(
-                        Label("The alert doesn't have detail"),
+                        Label("There is no detail to display"),
                         id="no_alert_details_label",
                     )
                     with VerticalScroll(id="alert_detail_pretty_container"):
@@ -78,7 +82,7 @@ class AlertDetails(Widget):
             with TabPane("Tags", id="tabpane-tags"):
                 with ContentSwitcher(initial=None, id="alert_details_tags_switcher"):
                     yield CenterMiddle(
-                        Label("The alert doesn't have a tag"), id="no_alert_tags_label"
+                        Label("There is not tag to display"), id="no_alert_tags_label"
                     )
                     with VerticalScroll(id="alert_tags_container"):
                         yield Tags(names=[], id="alert_tags_checkboxes")
@@ -87,14 +91,19 @@ class AlertDetails(Widget):
                     initial=None, id="alert_details_description_switcher"
                 ):
                     yield CenterMiddle(
-                        Label("The alert doesn't have description"),
+                        Label("There is no description to display"),
                         id="no_alert_description_label",
                     )
                     with VerticalScroll(id="alert_description_md_container"):
                         yield Markdown(None, id="pretty_alert_description")
             with TabPane("RAW", id="tabpane_raw"):
-                with VerticalScroll():
-                    yield Pretty(None, id="pretty_raw_alert_detail")
+                with ContentSwitcher(initial=None, id="alert_details_raw_switcher"):
+                    yield CenterMiddle(
+                        Label("There is no raw data to display"),
+                        id="no_alert_raw_label",
+                    )
+                    with VerticalScroll(id="alert_raw_pretty_container"):
+                        yield Pretty(None, id="pretty_raw_alert_detail")
 
     class UpdateAlertDetails(Message):
 

--- a/tygenie/widgets/alert_notes.py
+++ b/tygenie/widgets/alert_notes.py
@@ -23,7 +23,7 @@ class AlertNotes(Widget):
         content_switcher = ContentSwitcher(initial=None, id="alert_notes_switcher")
         with content_switcher:
             yield CenterMiddle(
-                Label("The alert doesn't have a note"), id="no_note_label"
+                Label("There is no alert note to display"), id="no_note_label"
             )
             with VerticalScroll(id="alert_notes_markdown_container"):
                 md = Markdown(None, name="Notes", id="md_alert_note")


### PR DESCRIPTION
This commit is adding the feature of using saved searches in opsgenie.
It also fixes some minor bug when we have no alert selected the alert detail and alert note widget are now empty instead of keeping the previous data.
Upgrade textual to 2.1.2