### PR TITLE
Fix unbound variable on API call exception

### DIFF
--- a/tygenie/opsgenie.py
+++ b/tygenie/opsgenie.py
@@ -147,7 +147,7 @@ class OpsGenie:
             return response.parsed
         except Exception as e:
             ty_logger.logger.log(f"Exception in API call: {e}")
-            return response
+            return None
 
     def _load_config(self):
         self.api_key = config.ty_config.opsgenie.get("api_key", "")


### PR DESCRIPTION
In case of exception in API call the response was returned but the variable was unbound, we set the response to None as it is the expected value.