### PR TITLE
This is a quick fix to prevent the application to crash when setting a

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 [project]
 name = "tygenie"
 license = { file = "LICENSE" }
-version = "1.12.0"
+version = "1.13.0"
 authors = [
   { name = "Pierre-Samuel Le Stang", email = "pierre-samuel.le-stang@corp.ovh.com" },
 ]

--- a/tygenie/widgets/input.py
+++ b/tygenie/widgets/input.py
@@ -31,4 +31,3 @@ class TagValueInput(Widget):
             )
             tag = self.query_one("#tag_input", Input)
             self.post_message(self.TagValueChange(label=tag.value))
-            self.app.query_one("#alerts_data_table").focus(True)


### PR DESCRIPTION
custom tag

The idea of gaining the focus after the tag have been customized should be kept but will be reimplemented later.