### PR TITLE
Upgrade textual to 5.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "python_dateutil==2.9.0.post0",
   "rich==13.9.4",
   "semver==3.0.1",
-  "textual[syntax]==3.5.0",
+  "textual[syntax]==5.0.1",
   "udatetime==0.0.17",
 ]
 requires-python = ">=3.11"


### PR DESCRIPTION
Tree-sitter had a breaking change in version 25.0.0. As a result, Tygenie crashes when adding a new note with the following error:

```
AttributeError: 'tree_sitter.Query' object has no attribute 'captures'
```

Textual released a fix[1] for this. Let's use it.

[1] https://github.com/Textualize/textual/issues/5976